### PR TITLE
Add backtick prevent column use the Reserved Words

### DIFF
--- a/export.py
+++ b/export.py
@@ -112,7 +112,7 @@ def create_sql_dump(db_file, dump_file, drop_table=True, export_mode="both"):
                     f.write(f"DROP TABLE IF EXISTS `{table}`;")
 
                 columns = ', '.join([
-                    f"{col[1]} {sqlite_to_mysql_type(col[2], max_lengths.get(col[1]), nullability.get(col[1]), max_values.get(col[1]))}"
+                    f"`{col[1]}` {sqlite_to_mysql_type(col[2], max_lengths.get(col[1]), nullability.get(col[1]), max_values.get(col[1]))}"
                     for col in columns_info
                 ])
                 table_create_query = f"\n\n-- Table structure for `{table}`\n"


### PR DESCRIPTION
### **User description**
when I use this export.py to convert the sqlite3 -> mysql
get the  Reserved Words problem in Columns
so I use the backtick to prevent this problem


___

### **PR Type**
enhancement


___

### **Description**
- Added backticks around column names in the SQL dump creation process to prevent issues with reserved words in MySQL.
- This change enhances the compatibility of the script when converting SQLite databases to MySQL.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.py</strong><dd><code>Add backticks to column names in SQL dump</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

export.py

<li>Added backticks around column names in SQL dump creation.<br> <li> Ensures compatibility with reserved words in MySQL.<br>


</details>


  </td>
  <td><a href="https://github.com/majidalavizadeh/sqlite-to-mysql/pull/2/files#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information